### PR TITLE
ed25519-dalek stable version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ed25519-dalek = "1.0.0-pre.4"
+ed25519-dalek = "1.0.0"
 hmac = "0.9"
 sha2 = "0.9"
 


### PR DESCRIPTION
Bump of stable release of ed25519-dalek crate.
Tests are passing after update.
Need this to align version with other crates to fix conflicting dependencies.

<img width="541" alt="Screen Shot 2020-08-21 at 1 47 41 PM" src="https://user-images.githubusercontent.com/13215338/90887622-0030b800-e3b5-11ea-9399-924248261724.png">
