### PR TITLE
chore: migrate to `ed25519-dalek` major version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slip10"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Ngo Iok Ui <wusyong9104@gmail.com>"]
 edition = "2018"
 description = "SLIP-0010 : Universal private key derivation from master private key"
@@ -13,7 +13,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ed25519-dalek = { version = "1.0", default-features = false, features = ["u64_backend"] }
+ed25519-dalek = "2"
 hmac = { version = "0.9", default-features = false }
 sha2 = { version = "0.9", default-features = false }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use alloc::vec::Vec;
 use core::convert::TryInto;
 use core::fmt;
 
-use ed25519_dalek::{PublicKey, SecretKey};
+use ed25519_dalek::{SigningKey, VerifyingKey};
 use hmac::{crypto_mac::Output, Hmac, Mac, NewMac};
 use sha2::Sha512;
 
@@ -65,7 +65,8 @@ impl Curve {
     fn public_key(&self, key: &[u8; 32]) -> Vec<u8> {
         match self {
             Curve::Ed25519 => {
-                let public: PublicKey = (&SecretKey::from_bytes(key).unwrap()).into();
+                let signing_key: SigningKey = SigningKey::from_bytes(key);
+                let public: VerifyingKey = signing_key.verifying_key();
                 let mut result = Vec::new();
                 result.push(0);
                 public.to_bytes().iter().for_each(|i| result.push(*i));


### PR DESCRIPTION
this may be a patch release only, as `ed25519-dalek` is not part of public interface of `slip10`

this pr addresses the following 2 vulnerabilities, as `ed25519-dalek 1.0.1` is considered unlikely to receive updates any time soon

```bash
❯ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 629 security advisories (from /home/user/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (27 crate dependencies)
Crate:     curve25519-dalek
Version:   3.2.1
Title:     Timing variability in `curve25519-dalek`'s `Scalar29::sub`/`Scalar52::sub`
Date:      2024-06-18
ID:        RUSTSEC-2024-0344
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0344
Solution:  Upgrade to >=4.1.3
Dependency tree:
curve25519-dalek 3.2.1
└── ed25519-dalek 1.0.1
    └── slip10 0.4.3
                                                                                                            
Crate:     ed25519-dalek
Version:   1.0.1
Title:     Double Public Key Signing Function Oracle Attack on `ed25519-dalek`
Date:      2022-06-11
ID:        RUSTSEC-2022-0093
URL:       https://rustsec.org/advisories/RUSTSEC-2022-0093
Solution:  Upgrade to >=2
Dependency tree:
ed25519-dalek 1.0.1
└── slip10 0.4.3
                                                                                                            
error: 2 vulnerabilities found!
```
